### PR TITLE
chore(docs): establece VSCode como editor de Typst

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "myriad-dreamin.tinymist",
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,5 +2,6 @@
     "recommendations": [
         "myriad-dreamin.tinymist",
         "ltex-plus.vscode-ltex-plus",
+        "mushan.vscode-paste-image",
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
         "myriad-dreamin.tinymist",
+        "ltex-plus.vscode-ltex-plus",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "ltex.latex.environments": {
+        "lstlisting": "ignore",
+        "verbatim": "ignore"
+    },
+    "ltex.language": "es",
+    "[typst]": {
+        "editor.formatOnSave": true
+    },
+    "tinymist.formatterPrintWidth": 80,
+    "tinymist.formatterProseWrap": true,
+}


### PR DESCRIPTION
# Issues trabajados

- [x] Closes #9 

El PR introduce VSCode para trabajar con Typst, instalando algunas extensiones.