### PR TITLE
ci(docs): compilación y revisión de gramática

### DIFF
--- a/.github/workflows/typst.yaml
+++ b/.github/workflows/typst.yaml
@@ -23,3 +23,67 @@ jobs:
         with:
           name: paper
           path: paper.pdf
+
+  grammar:
+    name: Checks the grammar with LanguageTool
+    needs: compile
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: "3.8.6"
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Set up cache
+        id: package-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.m2/repository/invalid/typst-languagetool/
+          key: ${{ runner.os }}-typst-languagetool-v1
+
+      - name: Install typst-languagetool package
+        run: cargo install --git=https://github.com/antonWetzel/typst-languagetool cli --features=bundle
+        if: steps.package-cache.outputs.cache-hit != 'true'
+
+      - name: Run Grammar Check
+        run: |
+          # Create wrapper script
+          cat > grammar-check-wrapper.sh << 'EOF'
+          #!/usr/bin/env bash
+          GRAMMAR_CHECKER="typst-languagetool"
+          OUTPUT_FILE="/tmp/grammar_check_output.txt"
+          ERROR_PATTERN="(info|Failed to compile document)"
+
+          # Run the grammar checker and capture its output
+          $GRAMMAR_CHECKER "$@" --bundle | tee "$OUTPUT_FILE"
+
+          # Check if the output contains any error indicators
+          if grep -Ei "$ERROR_PATTERN" "$OUTPUT_FILE" > /dev/null; then
+              echo "::error::Grammar issues found. Check the output above."
+              exit 1
+          else
+              echo "::notice::No grammar issues detected."
+              exit 0
+          fi
+          EOF
+          chmod +x grammar-check-wrapper.sh
+
+          # Use the wrapper script
+          ./grammar-check-wrapper.sh check --main=doc/main.typ --options=doc/dictionary.json

--- a/.github/workflows/typst.yaml
+++ b/.github/workflows/typst.yaml
@@ -1,0 +1,25 @@
+name: Typst Tasks
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**.typ'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.typ'
+  workflow_dispatch:
+
+jobs:
+  compile:
+    name: Compiles the typst project into a PDF
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: typst-community/setup-typst@v4
+      - run: typst compile doc/main.typ paper.pdf
+      - uses: actions/upload-artifact@v4
+        with:
+          name: paper
+          path: paper.pdf

--- a/.github/workflows/typst.yaml
+++ b/.github/workflows/typst.yaml
@@ -2,13 +2,13 @@ name: Typst Tasks
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - '**.typ'
+      - "**.typ"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - '**.typ'
+      - "**.typ"
   workflow_dispatch:
 
 jobs:

--- a/doc/dictionary.json
+++ b/doc/dictionary.json
@@ -1,0 +1,5 @@
+{
+    "dictionary": {
+        "es-ES": []
+    }
+}


### PR DESCRIPTION
# Issues trabajados

- [x] Closes: #2 
- [x] Closes: #3 

Para poder revisar tanto la compilación como la gramática, se han añadido dos acciones de GitHub que se activan cuando se modifica un fichero con la extensión de Typst.