### PR TITLE
fix(ci): typst-languagetool template especial

### DIFF
--- a/doc/main.typ
+++ b/doc/main.typ
@@ -1,5 +1,10 @@
 #import "template.typ": *
 
+// use styling for spellcheck only in the spellchecker
+// keep the correct styling in pdf or preview
+// should be called after the template
+#show: lt(overwrite: false)
+
 #show: project.with(
   title: "Placeholder title",
   subtitle: "Placeholder subtitle",

--- a/doc/template.typ
+++ b/doc/template.typ
@@ -366,4 +366,28 @@
 
   body
 }
+
+#let lt(overwrite: false, seperate-sections-level: 3) = {
+  if not sys.inputs.at("spellcheck", default: overwrite) {
+    return doc => doc
+  }
+  return doc => {
+    show math.equation.where(block: false): it => [0]
+    show math.equation.where(block: true): it => []
+    show bibliography: it => []
+    set par(justify: false, leading: 0.65em, hanging-indent: 0pt)
+    set page(height: auto)
+    show raw: set text(lang: "es", region: "ES")
+    show raw.where(block: false): it => [0]
+    show raw.where(block: true): it => []
+    show block: it => it.body
+    show page: set page(numbering: none)
+    show heading: it => if it.level <= seperate-sections-level {
+      pagebreak() + it
+    } else {
+      it
+    }
+    doc
+  }
+}
 //LTeX: enabled=true


### PR DESCRIPTION
Cambios recomendados por el autor, para no usar estilos en el pdf que genera para la corrección